### PR TITLE
changed the parser to allow & in the item name. fixed #3

### DIFF
--- a/bibtex-tests.js
+++ b/bibtex-tests.js
@@ -51,3 +51,10 @@ _.each(a, function(val, key) {
         }
     });
 });
+
+Tinytest.add("Ampersand in item name", function (test) {
+    var g = Bibtex.parse(Assets.getText("test/testAmpersandInItemName.bib")).entries;
+    _.each(g, function (e, key) {
+        test.equal(key, 'Billam&2015', 'Missing ampersand in item name');
+    });
+});

--- a/bibtex.js
+++ b/bibtex.js
@@ -200,7 +200,7 @@ function BibtexParser() {
                 throw new BibtexError("Runaway key", this);
             }
             
-            if (this.input[this.pos].match("[a-zA-Z0-9@_:\\./\?\+\-]")) {
+            if (this.input[this.pos].match("[a-zA-Z0-9@&_:\\./\?\+\-]")) {
                 this.pos++
             } else {
                 return this.input.substring(start, this.pos);

--- a/package.js
+++ b/package.js
@@ -32,4 +32,5 @@ Package.onTest(function(api) {
     api.addAssets('test/test1.json', ['server']);
     api.addAssets('test/test2.bib', ['server']);
     api.addAssets('test/test2.json', ['server']);
+    api.addAssets('test/testAmpersandInItemName.bib', ['server']);
 });

--- a/test/testAmpersandInItemName.bib
+++ b/test/testAmpersandInItemName.bib
@@ -1,0 +1,15 @@
+@article{ Billam&2015,
+  author = {Billam, T.P., Reeves, M.T., Bradley, A.S.},
+  title = {Spectral energy transport in two-dimensional quantum vortex dynamics},
+  journal = {Physical Review A - Atomic, Molecular, and Optical Physics},
+  year = {2015},
+  volume = {91},
+  number = {2},
+  doi = {10.1103/PhysRevA.91.023615},
+  art_number = {023615},
+  note = {cited By 0},
+  url = {http://www.scopus.com/inward/record.url?eid=2-s2.0-84923260904&partnerID=40&md5=4711b87ad42c2ee9edf5f82b5f22576f},
+  document_type = {Article},
+  source = {Scopus}
+}
+


### PR DESCRIPTION
This changes the parser to allow `&` in the item name. The fix include the parser regex change and a test to confirm that the item name was parsed correctly.
